### PR TITLE
Require Discord in setup.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,11 +23,9 @@ Or the freshest bleeding-edge code directly from GitHub_ using pip and git:
 
 .. note::
 
-    In both cases you also have to install `discord.py v1.0.0`_ manually from GitHub:
-
-    .. code-block:: bash
-
-        python3.6 -m pip install -U git+https://github.com/Rapptz/discord.py@rewrite
+    A compatible version of `discord.py` will be installed automatically when
+    downloading with pip. However, you should still require `discord.py` in
+    your own setup.py or requirements.txt file.
 
 
 Features

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+https://github.com/Rapptz/discord.py@rewrite
+.

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.rst', 'r', encoding='utf-8') as f:
 
 setup(
     name='disputils',
-    version='0.1.1',
+    version='0.1.2',
     description='Some utilities for discord.py. Making Discord bot development easier.',
     long_description=readme,
     long_description_content_type='text/x-rst',
@@ -18,6 +18,7 @@ setup(
         'Programming Language :: Python :: 3.6'
     ],
     python_requires='>=3.6',
+    install_requires=['discord.py >=1,<2'],
     keywords='discord discord-py discord-bot utils utility',
     packages=find_packages(exclude=['tests', 'docs']),
     data_files=None


### PR DESCRIPTION
Add the Discord.py library to `setup.py`. This means that it will be downloaded automatically during installation of Disputils if it is not already installed. Modified the `README.rst` file to remove the old instructions.

Bumped the version number to **0.1.2** due to this change. This will require uploading to PyPI once the pull request is merged.