### PR TITLE
fix embed property not being used when run

### DIFF
--- a/disputils/multiple_choice.py
+++ b/disputils/multiple_choice.py
@@ -134,7 +134,7 @@ class MultipleChoice(Dialog):
         timeout = kwargs.get("timeout", 60)
         closable: bool = kwargs.get("closable", True)
 
-        config_embed = self._generate_embed()
+        config_embed = self.embed
 
         if channel is not None:
             self.message = await channel.send(embed=config_embed)


### PR DESCRIPTION
closes #25 since footer and timestamp can now be set like this:
```python
mc = MultipleChoice(...)
mc.embed.set_footer(text="example", icon_url="https://example.com/icon.png")
mc.embed.timestamp = datetime.datetime.now()
await mc.run()
```