### PR TITLE
V0.2.0

### DIFF
--- a/disputils/__init__.py
+++ b/disputils/__init__.py
@@ -1,4 +1,4 @@
-from .pagination import EmbedPaginator, BotEmbedPaginator
+from .pagination import EmbedPaginator, BotEmbedPaginator, ControlEmojis
 from .confirmation import Confirmation, BotConfirmation
 from .multiple_choice import MultipleChoice, BotMultipleChoice
 from . import abc

--- a/disputils/confirmation.py
+++ b/disputils/confirmation.py
@@ -75,18 +75,18 @@ class Confirmation(Dialog):
             await msg.add_reaction(emoji)
 
         try:
-            reaction, user = await self._client.wait_for(
-                "reaction_add",
-                check=lambda r, u: (r.message.id == msg.id)
-                and (u.id == user.id)
-                and (r.emoji in self.emojis),
+            reaction = await self._client.wait_for(
+                "raw_reaction_add",
+                check=lambda r: (r.message_id == msg.id)
+                and (r.user_id == user.id)
+                and (str(r.emoji) in self.emojis),
                 timeout=timeout,
             )
         except asyncio.TimeoutError:
             self._confirmed = None
             return
         else:
-            self._confirmed = self.emojis[reaction.emoji]
+            self._confirmed = self.emojis[str(reaction.emoji)]
             return self._confirmed
         finally:
             try:

--- a/disputils/confirmation.py
+++ b/disputils/confirmation.py
@@ -35,7 +35,7 @@ class Confirmation(Dialog):
         user: discord.User,
         channel: discord.TextChannel = None,
         hide_author: bool = False,
-        timeout: int = 20
+        timeout: int = 20,
     ) -> bool or None:
         """
         Run the confirmation.
@@ -68,13 +68,8 @@ class Confirmation(Dialog):
 
         self._embed = emb
 
-        if channel is None and self.message is not None:
-            channel = self.message.channel
-        elif channel is None:
-            raise TypeError("Missing argument. You need to specify a target channel.")
-
-        msg = await channel.send(embed=emb)
-        self.message = msg
+        await self._publish(channel, embed=emb)
+        msg = self.message
 
         for emoji in self.emojis:
             await msg.add_reaction(emoji)
@@ -90,16 +85,14 @@ class Confirmation(Dialog):
         except asyncio.TimeoutError:
             self._confirmed = None
             return
+        else:
+            self._confirmed = self.emojis[reaction.emoji]
+            return self._confirmed
         finally:
             try:
                 await msg.clear_reactions()
             except discord.Forbidden:
                 pass
-
-        confirmed = self.emojis[reaction.emoji]
-
-        self._confirmed = confirmed
-        return confirmed
 
 
 class BotConfirmation(Confirmation):
@@ -119,7 +112,7 @@ class BotConfirmation(Confirmation):
         user: discord.User = None,
         channel: discord.TextChannel = None,
         hide_author: bool = False,
-        timeout: int = 20
+        timeout: int = 20,
     ) -> bool or None:
 
         if user is None:

--- a/disputils/pagination.py
+++ b/disputils/pagination.py
@@ -15,7 +15,17 @@ ControlEmojis = namedtuple(
 
 
 class EmbedPaginator(Dialog):
-    """ Represents an interactive menu containing multiple embeds. """
+    """
+    Represents an interactive menu containing multiple embeds.
+
+    :param client: The :class:`discord.Client` to use.
+    :param pages: A list of :class:`discord.Embed` to paginate through.
+    :param message: An optional :class:`discord.Message` to edit.
+        Otherwise a new message will be sent.
+    :param control_emojis: :class:`ControlEmojis`, `tuple` or `list`
+        containing control emojis to use, otherwise the default will be used.
+        A value of `None` causes a reaction to be left out.
+    """
 
     def __init__(
         self,
@@ -25,17 +35,6 @@ class EmbedPaginator(Dialog):
         *,
         control_emojis: Union[ControlEmojis, tuple, list] = ControlEmojis(),
     ):
-        """
-        Initialize a new EmbedPaginator.
-
-        :param client: The :class:`discord.Client` to use.
-        :param pages: A list of :class:`discord.Embed` to paginate through.
-        :param message: An optional :class:`discord.Message` to edit.
-            Otherwise a new message will be sent.
-        :param control_emojis: :class:`ControlEmojis`, `tuple` or `list`
-            containing control emojis to use, otherwise the default will be used.
-            A value of `None` causes a reaction to be left out.
-        """
         super().__init__()
 
         self._client = client
@@ -239,6 +238,18 @@ class EmbedPaginator(Dialog):
 
 
 class BotEmbedPaginator(EmbedPaginator):
+    """
+    Same as :class:`EmbedPaginator`, except for the discord.py commands extension.
+
+    :param ctx: The :class:`discord.ext.commands.Context` to use.
+    :param pages: A list of :class:`discord.Embed` to paginate through.
+    :param message: An optional :class:`discord.Message` to edit.
+        Otherwise a new message will be sent.
+    :param control_emojis: :class:`ControlEmojis`, `tuple` or `list`
+        containing control emojis to use, otherwise the default will be used.
+        A value of `None` causes a reaction to be left out.
+    """
+
     def __init__(
         self,
         ctx: commands.Context,
@@ -247,17 +258,6 @@ class BotEmbedPaginator(EmbedPaginator):
         *,
         control_emojis: Union[ControlEmojis, tuple, list] = ControlEmojis(),
     ):
-        """
-        Initialize a new EmbedPaginator.
-
-        :param ctx: The :class:`discord.ext.commands.Context` to use.
-        :param pages: A list of :class:`discord.Embed` to paginate through.
-        :param message: An optional :class:`discord.Message` to edit.
-            Otherwise a new message will be sent.
-        :param control_emojis: :class:`ControlEmojis`, `tuple` or `list`
-            containing control emojis to use, otherwise the default will be used.
-            A value of `None` causes a reaction to be left out.
-        """
         self._ctx = ctx
 
         super(BotEmbedPaginator, self).__init__(


### PR DESCRIPTION
Improvements:
 - listen for `raw_reaction_add` instead of `reaction_add` to not be reliant on message cache
 - add keyword arguments to `run` method
   * add `timeout` to customize timeout time for pagination, multiple choice and confirmation (#34)
   * add `text`, `timeout_msg` and `quit_msg` for pagination and multiple choice (427bd24)
  
Fix:
 - `run` method not editing `self.message`, but instead sending a new one